### PR TITLE
More proper fix for #4083 (IMO), more useful failure messages

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -302,7 +302,7 @@ class Metasploit3 < Msf::Auxiliary
         next
       end
 
-      if res and res.code == 401 and res['WWW-Authenticate'].match(/^NTLM/i)
+      if res && res.code == 401 && res.headers.has_key?('WWW-Authenticate') && res.headers['WWW-Authenticate'].match(/^NTLM/i)
         hash = res['WWW-Authenticate'].split('NTLM ')[1]
         domain = Rex::Proto::NTLM::Message.parse(Rex::Text.decode_base64(hash))[:target_name].value().gsub(/\0/,'')
         print_good("Found target domain: " + domain)


### PR DESCRIPTION
I believe what is in rapid7/metasploit-framework#4083 is actually caused by a lack of cookies in the response, and that the login attempt should abort earlier rather than continuing to try as in rapid7/metasploit-framework#4094.  

While here, I also cleaned up the vprint_error messages for the login failure cases, which makes debugging this module much easier.
## Validation

First, `apt-get install apache2 ; a2enmod '*header*' ; /etc/init.d/apache start;`
- [x] Test against an HTTP server that responds positively for the OWA 2010 URLs (`mkdir /var/www/owa; touch /var/www/owa/auth.owa`, and then with `mod_headers`, set different header values and test:
  - [x] No cookies set
  - [x] `Header set Set-Cookie testcookie=foo;` # with cookies, but none of the right ones
  - [x] `Header set Set-Cookie sessionid=;`` # has one of the necessary cookies but it is empty
  - [x] `Header set Set-Cookie "foo=bar; path=/;sessionid=f;cadata=adfasdf;"` # has all of the necessary cookies
- [ ] Test valid/invalid logins against real OWA 2013
- [x] Test valid/invalid logins against real OWA 2010
